### PR TITLE
feat(linter): add proper ast traversal linting system

### DIFF
--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -1,0 +1,17 @@
+use crate::linter::Rule;
+
+mod host_source_is_self;
+mod insecure_scheme;
+mod missing_source;
+mod repeated_directive;
+mod repeated_source;
+
+pub fn get_rules() -> Vec<Box<dyn Rule>> {
+    vec![
+        Box::new(host_source_is_self::HostSourceIsSelf {}),
+        Box::new(insecure_scheme::InsecureScheme {}),
+        Box::new(missing_source::MissingSource {}),
+        Box::new(repeated_directive::RepeatedDirective {}),
+        Box::new(repeated_source::RepeatedSource {}),
+    ]
+}

--- a/src/linter/rules/host_source_is_self.rs
+++ b/src/linter/rules/host_source_is_self.rs
@@ -1,0 +1,51 @@
+use crate::{
+    linter::{Node, Rule},
+    policy::{DirectiveKind, Host, HostSource, SchemeSource, SourceExpression},
+    report::{Issue, Report, Severity},
+};
+
+pub struct HostSourceIsSelf {}
+
+impl Rule for HostSourceIsSelf {
+    fn check(&self, origin: Option<String>, report: &mut Report, node: Node) {
+        let Node::Directive(directive) = node else {
+            return;
+        };
+
+        let Some(ref origin) = origin else {
+            return;
+        };
+
+        if let DirectiveKind::Unknown(_) = directive.kind {
+            return;
+        }
+
+        if directive.kind.must_have_no_source() {
+            return;
+        }
+
+        for source in &directive.sources {
+            let SourceExpression::Host(host) = &source.expression else {
+                continue;
+            };
+            let HostSource {
+                scheme: Some(SchemeSource::Https),
+                host: Host::Fqdn(fqdn),
+                port: None,
+                path: None,
+            } = host
+            else {
+                continue;
+            };
+
+            if fqdn == origin {
+                report.add_issue(
+                    Issue::builder()
+                        .severity(Severity::Low)
+                        .description(format!("Host source \"{}\" in directive \"{}\" is the page origin. It can be replaced with 'self'", &fqdn, directive.kind))
+                        .build(),
+                );
+            }
+        }
+    }
+}

--- a/src/linter/rules/insecure_scheme.rs
+++ b/src/linter/rules/insecure_scheme.rs
@@ -1,0 +1,49 @@
+use crate::{
+    linter::{Node, Rule},
+    policy::{DirectiveKind, HostSource, SchemeSource, SourceExpression},
+    report::{Issue, Report, Severity},
+};
+
+pub struct InsecureScheme {}
+
+impl Rule for InsecureScheme {
+    fn check(&self, _origin: Option<String>, report: &mut Report, node: Node) {
+        let Node::Directive(directive) = node else {
+            return;
+        };
+
+        if let DirectiveKind::Unknown(_) = directive.kind {
+            return;
+        }
+
+        if directive.kind.must_have_no_source() {
+            return;
+        }
+
+        for source in &directive.sources {
+            let scheme = match &source.expression {
+                SourceExpression::Host(HostSource {
+                    scheme: Some(scheme),
+                    ..
+                }) => scheme,
+                SourceExpression::Scheme(scheme) => scheme,
+                _ => continue,
+            };
+
+            match scheme {
+                SchemeSource::Http | SchemeSource::Ws => {
+                    report.add_issue(
+                        Issue::builder()
+                            .severity(Severity::Medium)
+                            .description(format!(
+                                "Insecure scheme \"{}\" used in directive \"{}\".",
+                                &scheme, &directive.kind
+                            ))
+                            .build(),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/linter/rules/missing_source.rs
+++ b/src/linter/rules/missing_source.rs
@@ -1,0 +1,31 @@
+use crate::{
+    linter::{Node, Rule},
+    policy::DirectiveKind,
+    report::{Issue, Report, Severity},
+};
+
+pub struct MissingSource {}
+
+impl Rule for MissingSource {
+    fn check(&self, _origin: Option<String>, report: &mut Report, node: Node) {
+        let Node::Directive(directive) = node else {
+            return;
+        };
+
+        if let DirectiveKind::Unknown(_) = directive.kind {
+            return;
+        }
+
+        if !directive.kind.must_have_no_source() && directive.sources.is_empty() {
+            report.add_issue(
+                Issue::builder()
+                    .severity(Severity::High)
+                    .description(format!(
+                        "Missing source for directive \"{}\". Directive has no effect.",
+                        &directive.kind
+                    ))
+                    .build(),
+            );
+        }
+    }
+}

--- a/src/linter/rules/repeated_directive.rs
+++ b/src/linter/rules/repeated_directive.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use crate::{
+    linter::{Node, Rule},
+    policy::{Directive, DirectiveKind},
+    report::{Issue, Report, Severity},
+};
+
+pub struct RepeatedDirective {}
+
+impl Rule for RepeatedDirective {
+    fn check(&self, _origin: Option<String>, report: &mut Report, node: Node) {
+        let Node::Policy(policy) = node else {
+            return;
+        };
+
+        let mut directives_by_kind = HashMap::<DirectiveKind, Vec<&Directive>>::new();
+        for directive in &policy.directives {
+            directives_by_kind
+                .entry(directive.kind.clone())
+                .or_default()
+                .push(directive);
+        }
+
+        for (kind, directives) in directives_by_kind {
+            if directives.len() > 1 {
+                report.add_issue(
+                    Issue::builder()
+                        .severity(Severity::Medium)
+                        .description(format!("Repeated directive: \"{}\" is declared {} times. Only the first declaration is applied.", kind, directives.len()))
+                        .build(),
+                );
+            }
+        }
+    }
+}

--- a/src/linter/rules/repeated_source.rs
+++ b/src/linter/rules/repeated_source.rs
@@ -1,0 +1,35 @@
+use std::collections::HashSet;
+
+use crate::{
+    linter::{Node, Rule},
+    report::{Issue, Report, Severity},
+};
+
+pub struct RepeatedSource {}
+
+impl Rule for RepeatedSource {
+    fn check(&self, _origin: Option<String>, report: &mut Report, node: Node) {
+        let Node::Directive(directive) = node else {
+            return;
+        };
+
+        let mut seen = HashSet::new();
+
+        for source in &directive.sources {
+            let source = &source.expression;
+            if seen.contains(&source) {
+                report.add_issue(
+                    Issue::builder()
+                        .severity(Severity::Low)
+                        .description(format!(
+                            "Repeated source \"{}\" in directive \"{}\".",
+                            &source, &directive.kind
+                        ))
+                        .build(),
+                );
+            } else {
+                seen.insert(source);
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use cli::Commands;
-use report::{Severity, Smell};
+use report::{Issue, Severity};
 use reqwest::redirect::Policy as RedirectPolicy;
 
 use crate::cli::Cli;
@@ -74,22 +74,22 @@ async fn main() -> ExitCode {
 
             match (enforce_set.first(), report_set.first()) {
                 (None, None) => {
-                    report.add_smell(
-                        Smell::builder()
+                    report.add_issue(
+                        Issue::builder()
                             .severity(Severity::Critical)
                             .description("No Content-Security-Policy header found".to_string())
                             .build(),
                     );
                 }
                 (None, Some(_)) => {
-                    report.add_smell(Smell::builder()
+                    report.add_issue(Issue::builder()
                         .severity(Severity::High)
                         .description("No Content-Security-Policy header found, only CSP-Report-Only header found".to_string())
                         .build());
                 }
                 (Some(_), Some(_)) => {
-                    report.add_smell(
-                        Smell::builder()
+                    report.add_issue(
+                        Issue::builder()
                             .severity(Severity::Low)
                             .description("Both CSP and CSP-Report-Only headers found".to_string())
                             .build(),
@@ -102,8 +102,8 @@ async fn main() -> ExitCode {
                 let policy = match parse_policy(csp, PolicyMode::Enforce) {
                     Ok(policy) => policy,
                     Err(err) => {
-                        report.add_smell(
-                            Smell::builder()
+                        report.add_issue(
+                            Issue::builder()
                                 .severity(Severity::Critical)
                                 .description(format!(
                                     "Malformed Content-Security-Policy header: {}",

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -136,7 +136,7 @@ pub struct HashSource {
 pub struct NonceSource(pub String);
 
 impl DirectiveKind {
-    pub fn must_have_no_policy(&self) -> bool {
+    pub fn must_have_no_source(&self) -> bool {
         use DirectiveKind::*;
 
         matches!(

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,7 +2,7 @@ use bon::Builder;
 use colored::Colorize;
 
 pub struct Report {
-    smells: Vec<Smell>,
+    smells: Vec<Issue>,
 }
 
 impl Report {
@@ -10,7 +10,7 @@ impl Report {
         Self { smells: Vec::new() }
     }
 
-    pub fn add_smell(&mut self, smell: Smell) {
+    pub fn add_issue(&mut self, smell: Issue) {
         self.smells.push(smell);
     }
 
@@ -40,7 +40,7 @@ impl Report {
 }
 
 #[derive(Builder, Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct Smell {
+pub struct Issue {
     description: String,
     severity: Severity,
 }


### PR DESCRIPTION
Add `Rule` trait to represent linter rule and mechanism to traverse CSP ast to apply each rules.

Existing rules are refactored based on that structure.